### PR TITLE
task/point to fork native elements

### DIFF
--- a/lib/components/Conversations/types.js
+++ b/lib/components/Conversations/types.js
@@ -1,2 +1,1 @@
-export {};
 //# sourceMappingURL=types.js.map

--- a/package-lock.json
+++ b/package-lock.json
@@ -4233,6 +4233,7 @@
       "version": "16.9.56",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.56.tgz",
       "integrity": "sha512-gIkl4J44G/qxbuC6r2Xh+D3CGZpJ+NdWTItAPmZbR5mUS+JQ8Zvzpl0ea5qT/ZT3ZNTUcDKUVqV3xBE8wv/DyQ==",
+      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -4242,6 +4243,7 @@
       "version": "0.63.48",
       "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.63.48.tgz",
       "integrity": "sha512-6+7WsHfVkcYEwO/u3wxarMwZq/mbJZ5iDYCXwX5bs8lm0vEIuBdMsk9jrwxuCBvaXhGdB0lriwTgfew/7VN2Kg==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       },
@@ -4250,6 +4252,7 @@
           "version": "17.0.1",
           "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.1.tgz",
           "integrity": "sha512-w8t9f53B2ei4jeOqf/gxtc2Sswnc3LBK5s0DyJcg5xd10tMHXts2N31cKjWfH9IC/JvEPa/YF1U4YeP1t4R6HQ==",
+          "dev": true,
           "requires": {
             "@types/prop-types": "*",
             "csstype": "^3.0.2"
@@ -4261,6 +4264,7 @@
       "version": "6.4.6",
       "resolved": "https://registry.npmjs.org/@types/react-native-vector-icons/-/react-native-vector-icons-6.4.6.tgz",
       "integrity": "sha512-lAyxNfMd5L1xZvXWsGcJmNegDf61TAp40uL6ashNNWj9W3IrDJO59L9+9inh0Y2MsEZpLTdxzVU8Unb4/0FQng==",
+      "dev": true,
       "requires": {
         "@types/react": "*",
         "@types/react-native": "*"
@@ -19195,10 +19199,9 @@
       "integrity": "sha1-eIO1ayCgAu63kMET+GFuqGksp5U="
     },
     "react-native-elements": {
-      "version": "git+https://github.com/lewong/react-native-elements.git#ab0526b053ab8a927da94a916ac1d584c2390790",
-      "from": "git+https://github.com/lewong/react-native-elements.git",
+      "version": "git+https://github.com/lewong/react-native-elements.git#5d13111635c82760ccc5ce3272ecd50fe900fbd3",
+      "from": "git+https://github.com/lewong/react-native-elements.git#5d131116",
       "requires": {
-        "@types/react-native-vector-icons": "^6.4.6",
         "color": "^3.1.2",
         "deepmerge": "^4.2.2",
         "hoist-non-react-statics": "^3.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7483,6 +7483,11 @@
         "estraverse": "^4.2.0"
       }
     },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -19190,9 +19195,8 @@
       "integrity": "sha1-eIO1ayCgAu63kMET+GFuqGksp5U="
     },
     "react-native-elements": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-native-elements/-/react-native-elements-3.2.0.tgz",
-      "integrity": "sha512-DgilI1P/S8xV3Uh6sjS7v1H7DsBXhlivG1IwHGJCO3OV3aFNh90bcdcmlKzxLZXWghQItqh9hQR3TLmgaZbU1w==",
+      "version": "git+https://github.com/lewong/react-native-elements.git#ab0526b053ab8a927da94a916ac1d584c2390790",
+      "from": "git+https://github.com/lewong/react-native-elements.git",
       "requires": {
         "@types/react-native-vector-icons": "^6.4.6",
         "color": "^3.1.2",
@@ -19203,13 +19207,6 @@
         "prop-types": "^15.7.2",
         "react-native-ratings": "^7.3.0",
         "react-native-size-matters": "^0.3.1"
-      },
-      "dependencies": {
-        "deepmerge": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-          "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
-        }
       }
     },
     "react-native-gifted-chat": {
@@ -19250,9 +19247,9 @@
       }
     },
     "react-native-ratings": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/react-native-ratings/-/react-native-ratings-7.3.0.tgz",
-      "integrity": "sha512-NCDIkmrVPnxPzP9zKdlcNpa2rPs3Hiv2qXsojUr3FpwbANWfgYE+jjGSSCBcS3vpXndTjhoaTGFDnybnUSFPFA==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/react-native-ratings/-/react-native-ratings-7.4.0.tgz",
+      "integrity": "sha512-3Zk1rDCl1TA7iI68PJDBbdCw+aQ+cvG/gcG3IVyyrTGlxdV+aAfAzFgICAAoPkYNuivIAO1eV0vSGoG9bboudg==",
       "requires": {
         "lodash": "^4.17.15",
         "prop-types": "^15.7.2"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "pluralize": "^8.0.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "react-native-elements": "^3.2.0",
+    "react-native-elements": "git+https://github.com/lewong/react-native-elements.git",
     "react-native-gifted-chat": "^0.16.3",
     "react-native-iphone-x-helper": "^1.3.1",
     "react-native-safe-area-context": "3.1.4",

--- a/package.json
+++ b/package.json
@@ -28,12 +28,13 @@
     "pluralize": "^8.0.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "react-native-elements": "git+https://github.com/lewong/react-native-elements.git",
+    "react-native-elements": "git+https://github.com/lewong/react-native-elements.git#5d131116",
     "react-native-gifted-chat": "^0.16.3",
     "react-native-iphone-x-helper": "^1.3.1",
     "react-native-safe-area-context": "3.1.4",
     "react-native-svg": "^12.1.0",
-    "react-native-unimodules": "^0.11.0"
+    "react-native-unimodules": "^0.11.0",
+    "react-native-vector-icons": "^8.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.6",
@@ -46,6 +47,7 @@
     "@types/pluralize": "0.0.29",
     "@types/react": "~16.9.35",
     "@types/react-native": "~0.63.2",
+    "@types/react-native-vector-icons": "^6.4.6",
     "babel-eslint": "10.1.0",
     "babel-jest": "~25.2.6",
     "babel-plugin-module-resolver": "^4.0.0",
@@ -64,7 +66,6 @@
     "jest": "^26.6.3",
     "jest-expo": "^39.0.0",
     "prettier": "2.2.0",
-    "react-native-vector-icons": "^8.0.0",
     "react-test-renderer": "~16.13.1",
     "typescript": "^3.9.7",
     "watch": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "react-native-iphone-x-helper": "^1.3.1",
     "react-native-safe-area-context": "3.1.4",
     "react-native-svg": "^12.1.0",
-    "react-native-unimodules": "^0.11.0",
-    "react-native-vector-icons": "^8.0.0"
+    "react-native-unimodules": "^0.11.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.6",
@@ -65,6 +64,7 @@
     "jest": "^26.6.3",
     "jest-expo": "^39.0.0",
     "prettier": "2.2.0",
+    "react-native-vector-icons": "^8.0.0",
     "react-test-renderer": "~16.13.1",
     "typescript": "^3.9.7",
     "watch": "^1.0.2",


### PR DESCRIPTION
This points to a fork of react-native-elements and moves @types/react-native-vector-icons to devDependencies:
https://github.com/lewong/react-native-elements/blob/remove-types-from-dependencies/package.json

@types/react-native-vector-icons is the problem package that pulls in @types/react and @types/react-native
